### PR TITLE
Add tooling for performance report comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ The batch processor exposes tuned profiles that map to the RTX 5090 + AMD 9950x 
 Invoke `scripts/process_batch.py --profile <balanced|throughput|latency>` to pick a profile, or
 `--benchmark` to emit a detailed `performance_report.json` containing throughput, GPU, CPU, and memory
 statistics collected during the run.
+
+Use `scripts/compare_performance_reports.py performance_report_*.json` to aggregate multiple runs into
+`performance_comparison.json` and highlight the highest-throughput and lowest-latency configurations.

--- a/scripts/compare_performance_reports.py
+++ b/scripts/compare_performance_reports.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+for candidate in (SRC_ROOT, PROJECT_ROOT):
+    candidate_str = str(candidate)
+    if candidate.exists() and candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
+from MinerUExperiment.metrics import compare_performance_reports
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare multiple MinerU performance reports",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "reports",
+        nargs="+",
+        type=Path,
+        help="Paths to performance_report.json files",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Destination for aggregated comparison report",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        destination = compare_performance_reports(args.reports, output_path=args.output)
+    except Exception as exc:
+        print(f"Comparison failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Comparison report written to {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/MinerUExperiment/__init__.py
+++ b/src/MinerUExperiment/__init__.py
@@ -14,7 +14,7 @@ from .mineru_config import (
     write_config,
 )
 from .mineru_runner import MineruInvocationError, MineruProcessResult, process_pdf
-from .metrics import MetricsCollector
+from .metrics import MetricsCollector, compare_performance_reports, load_performance_report
 from .validation import (
     RunMetrics,
     ValidationFailure,
@@ -31,6 +31,8 @@ __all__ = [
     "GPUInfo",
     "GPUUnavailableError",
     "MetricsCollector",
+    "compare_performance_reports",
+    "load_performance_report",
     "enforce_gpu_environment",
     "ensure_model_downloaded",
     "get_gpu_info",


### PR DESCRIPTION
## Summary
- add helpers to load and compare performance reports alongside the batch metrics collector
- expose a CLI utility for aggregating multiple runs and document the comparison workflow
- expand validation tests to cover the comparison report generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4ad2ab5f8832fbd60e95bc2b313cf