### PR TITLE
Implement structured markdown post-processing

### DIFF
--- a/openspec/changes/add-enhanced-markdown-generation/tasks.md
+++ b/openspec/changes/add-enhanced-markdown-generation/tasks.md
@@ -2,56 +2,56 @@
 
 ## 1. Markdown Builder Module
 
-- [ ] 1.1 Create `src/MinerUExperiment/markdown_builder.py`
-- [ ] 1.2 Implement function to load content_list.json
-- [ ] 1.3 Implement blocks_to_markdown() converter
-- [ ] 1.4 Add text_level to heading mapper (1→#, 2→##, etc.)
-- [ ] 1.5 Add table block handler (preserve HTML)
-- [ ] 1.6 Add equation block handler (LaTeX with $$ wrapper)
-- [ ] 1.7 Add image block handler (Markdown image + caption)
-- [ ] 1.8 Add other content type handlers (code, list, etc.)
-- [ ] 1.9 Implement blank line normalization (max 2 consecutive)
+- [x] 1.1 Create `src/MinerUExperiment/markdown_builder.py`
+- [x] 1.2 Implement function to load content_list.json
+- [x] 1.3 Implement blocks_to_markdown() converter
+- [x] 1.4 Add text_level to heading mapper (1→#, 2→##, etc.)
+- [x] 1.5 Add table block handler (preserve HTML)
+- [x] 1.6 Add equation block handler (LaTeX with $$ wrapper)
+- [x] 1.7 Add image block handler (Markdown image + caption)
+- [x] 1.8 Add other content type handlers (code, list, etc.)
+- [x] 1.9 Implement blank line normalization (max 2 consecutive)
 
 ## 2. Content Type Handling
 
-- [ ] 2.1 Handle "text" blocks with text_level for headings
-- [ ] 2.2 Handle "text" blocks without text_level as paragraphs
-- [ ] 2.3 Handle "table" blocks (extract HTML from html or content field)
-- [ ] 2.4 Handle "equation" blocks (extract LaTeX from content or latex field)
-- [ ] 2.5 Handle "image" blocks (extract img_path and img_caption)
-- [ ] 2.6 Handle "image_caption" blocks (if separate from image)
-- [ ] 2.7 Handle "code" and "algorithm" blocks
-- [ ] 2.8 Handle "list" blocks
-- [ ] 2.9 Gracefully handle unknown block types
+- [x] 2.1 Handle "text" blocks with text_level for headings
+- [x] 2.2 Handle "text" blocks without text_level as paragraphs
+- [x] 2.3 Handle "table" blocks (extract HTML from html or content field)
+- [x] 2.4 Handle "equation" blocks (extract LaTeX from content or latex field)
+- [x] 2.5 Handle "image" blocks (extract img_path and img_caption)
+- [x] 2.6 Handle "image_caption" blocks (if separate from image)
+- [x] 2.7 Handle "code" and "algorithm" blocks
+- [x] 2.8 Handle "list" blocks
+- [x] 2.9 Gracefully handle unknown block types
 
 ## 3. Output File Generation
 
-- [ ] 3.1 Generate .structured.md filename from content_list.json path
-- [ ] 3.2 Write UTF-8 encoded Markdown file
-- [ ] 3.3 Preserve original Markdown for comparison
-- [ ] 3.4 Log successful generation with file paths
+- [x] 3.1 Generate .structured.md filename from content_list.json path
+- [x] 3.2 Write UTF-8 encoded Markdown file
+- [x] 3.3 Preserve original Markdown for comparison
+- [x] 3.4 Log successful generation with file paths
 
 ## 4. Standalone CLI Script
 
-- [ ] 4.1 Create `scripts/postprocess_markdown.py`
-- [ ] 4.2 Accept directory path as argument
-- [ ] 4.3 Recursively find all *_content_list.json files
-- [ ] 4.4 Process each file and generate .structured.md
-- [ ] 4.5 Display progress and summary
+- [x] 4.1 Create `scripts/postprocess_markdown.py`
+- [x] 4.2 Accept directory path as argument
+- [x] 4.3 Recursively find all *_content_list.json files
+- [x] 4.4 Process each file and generate .structured.md
+- [x] 4.5 Display progress and summary
 
 ## 5. Integration with Batch Processing
 
-- [ ] 5.1 Modify batch_processor.py to call markdown post-processing
-- [ ] 5.2 Run post-processing after MinerU completes for each PDF
-- [ ] 5.3 Ensure .structured.md files are saved to MDFilesCreated
-- [ ] 5.4 Handle post-processing errors without failing entire batch
+- [x] 5.1 Modify batch_processor.py to call markdown post-processing
+- [x] 5.2 Run post-processing after MinerU completes for each PDF
+- [x] 5.3 Ensure .structured.md files are saved to MDFilesCreated
+- [x] 5.4 Handle post-processing errors without failing entire batch
 
 ## 6. Testing
 
-- [ ] 6.1 Test with sample content_list.json files
-- [ ] 6.2 Verify heading hierarchy is correct
-- [ ] 6.3 Verify tables are preserved as HTML
-- [ ] 6.4 Verify equations are properly wrapped in $$
-- [ ] 6.5 Verify images and captions are inline
-- [ ] 6.6 Compare with original Markdown for quality
-- [ ] 6.7 Test with edge cases (no headings, all tables, etc.)
+- [x] 6.1 Test with sample content_list.json files
+- [x] 6.2 Verify heading hierarchy is correct
+- [x] 6.3 Verify tables are preserved as HTML
+- [x] 6.4 Verify equations are properly wrapped in $$
+- [x] 6.5 Verify images and captions are inline
+- [x] 6.6 Compare with original Markdown for quality
+- [x] 6.7 Test with edge cases (no headings, all tables, etc.)

--- a/scripts/postprocess_markdown.py
+++ b/scripts/postprocess_markdown.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Standalone script for generating structured Markdown outputs."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, List
+
+from MinerUExperiment.markdown_builder import (
+    MarkdownGenerationError,
+    generate_structured_markdown,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+def _find_content_lists(root: Path) -> List[Path]:
+    return sorted(root.rglob("*_content_list.json"))
+
+
+def _process_paths(paths: Iterable[Path]) -> tuple[int, int]:
+    processed = 0
+    errors = 0
+    for path in paths:
+        LOGGER.info("Processing %s", path)
+        try:
+            generate_structured_markdown(path)
+        except (FileNotFoundError, MarkdownGenerationError) as exc:
+            LOGGER.error("Failed to process %s: %s", path, exc)
+            errors += 1
+        except Exception:  # pragma: no cover - unexpected
+            LOGGER.exception("Unexpected error while processing %s", path)
+            errors += 1
+        else:
+            processed += 1
+    return processed, errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate .structured.md files for MinerU outputs by processing "
+            "*_content_list.json files recursively."
+        )
+    )
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="Directory containing MinerU output files",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging output",
+    )
+
+    args = parser.parse_args()
+
+    _configure_logging(args.verbose)
+
+    target_dir = args.directory.expanduser().resolve()
+    if not target_dir.exists():
+        raise FileNotFoundError(f"Directory does not exist: {target_dir}")
+    if not target_dir.is_dir():
+        raise NotADirectoryError(f"Not a directory: {target_dir}")
+
+    content_lists = _find_content_lists(target_dir)
+    if not content_lists:
+        LOGGER.info("No *_content_list.json files found in %s", target_dir)
+        return
+
+    LOGGER.info("Found %d content list files", len(content_lists))
+    processed, errors = _process_paths(content_lists)
+    LOGGER.info("Structured Markdown generated for %d files", processed)
+    if errors:
+        LOGGER.warning("Encountered %d errors during processing", errors)
+    else:
+        LOGGER.info("Completed without errors")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/src/MinerUExperiment/markdown_builder.py
+++ b/src/MinerUExperiment/markdown_builder.py
@@ -1,0 +1,272 @@
+"""Utilities for constructing structured Markdown from MinerU content blocks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Callable, Iterable, List, Mapping, MutableSequence, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MarkdownGenerationError(RuntimeError):
+    """Raised when structured Markdown cannot be generated."""
+
+
+Block = Mapping[str, Any]
+
+
+def load_content_list(path: Path | str) -> List[Block]:
+    """Load and validate a MinerU ``content_list.json`` file.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON document.
+
+    Returns
+    -------
+    List[Block]
+        Parsed list of content blocks.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    MarkdownGenerationError
+        If the JSON is invalid or does not describe a list of blocks.
+    """
+
+    content_path = Path(path)
+    if not content_path.exists():
+        raise FileNotFoundError(f"content_list.json not found: {content_path}")
+
+    try:
+        with content_path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise MarkdownGenerationError(
+            f"Invalid JSON in {content_path}: {exc.msg}"
+        ) from exc
+
+    if not isinstance(data, list):
+        raise MarkdownGenerationError(
+            f"Expected list of blocks in {content_path}, got {type(data).__name__}"
+        )
+
+    return data
+
+
+def blocks_to_markdown(blocks: Sequence[Block]) -> str:
+    """Transform a sequence of MinerU blocks into Markdown text."""
+
+    rendered_blocks: MutableSequence[str] = []
+
+    for block in blocks:
+        if not isinstance(block, Mapping):  # pragma: no cover - defensive
+            LOGGER.warning("Skipping non-mapping block: %r", block)
+            continue
+
+        block_type = str(block.get("type") or "text").lower()
+
+        handler = _BLOCK_RENDERERS.get(block_type, _render_unknown)
+        rendered = handler(block)
+
+        if rendered:
+            rendered_blocks.append(rendered)
+
+    markdown = "\n\n".join(rendered_blocks)
+    return _normalize_markdown(markdown)
+
+
+def generate_structured_markdown(
+    content_list_path: Path | str,
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    """Generate a ``.structured.md`` file from *content_list_path*.
+
+    Parameters
+    ----------
+    content_list_path:
+        Path to the ``*_content_list.json`` file.
+    output_path:
+        Optional explicit output path. If omitted, the output path is derived
+        from *content_list_path*.
+    """
+
+    content_path = Path(content_list_path)
+    blocks = load_content_list(content_path)
+    markdown = blocks_to_markdown(blocks)
+
+    if output_path is None:
+        output_path = structured_markdown_path(content_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+
+    LOGGER.info(
+        "Generated structured Markdown: %s -> %s", content_path, output_path
+    )
+
+    return output_path
+
+
+def structured_markdown_path(content_list_path: Path | str) -> Path:
+    """Return the derived ``.structured.md`` path for *content_list_path*."""
+
+    content_path = Path(content_list_path)
+    name = content_path.name
+    if name.endswith("_content_list.json"):
+        base = name[: -len("_content_list.json")]
+        new_name = f"{base}.structured.md"
+    else:
+        new_name = f"{content_path.stem}.structured.md"
+    return content_path.with_name(new_name)
+
+
+def _extract_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Iterable):
+        return "\n".join(str(part).strip() for part in value if part)
+    return str(value).strip()
+
+
+def _render_text(block: Block) -> str:
+    text_level = block.get("text_level")
+    content = _extract_text(block.get("content"))
+    if not content:
+        return ""
+
+    try:
+        level = int(text_level)
+    except (TypeError, ValueError):
+        level = 0
+
+    if level <= 0:
+        return content
+
+    level = max(1, min(level, 6))
+    heading_prefix = "#" * level
+    return f"{heading_prefix} {content}"
+
+
+def _render_table(block: Block) -> str:
+    html = _extract_text(block.get("html"))
+    if not html:
+        html = _extract_text(block.get("content"))
+
+    if not html:
+        LOGGER.warning("Skipping empty table block")
+        return ""
+
+    return html
+
+
+def _render_equation(block: Block) -> str:
+    latex = _extract_text(block.get("latex")) or _extract_text(block.get("content"))
+    if not latex:
+        LOGGER.warning("Skipping empty equation block")
+        return ""
+
+    stripped = latex.strip()
+    if stripped.startswith("$$") and stripped.endswith("$$"):
+        body = stripped[2:-2].strip()
+        return f"$$\n{body}\n$$"
+
+    return f"$$\n{stripped}\n$$"
+
+
+def _render_image(block: Block) -> str:
+    path = _extract_text(block.get("img_path") or block.get("path"))
+    if not path:
+        LOGGER.warning("Skipping image block without img_path")
+        return ""
+
+    caption_raw = block.get("img_caption") or block.get("caption")
+    if isinstance(caption_raw, (list, tuple)):
+        caption_parts = [
+            str(part).strip() for part in caption_raw if str(part).strip()
+        ]
+        caption = " ".join(caption_parts)
+    else:
+        caption = _extract_text(caption_raw)
+
+    alt_text = caption or ""
+    parts = [f"![{alt_text}]({path})"]
+    if caption:
+        parts.append(f"*{caption}*")
+    return "\n".join(parts)
+
+
+def _render_image_caption(block: Block) -> str:
+    caption_raw = block.get("content") or block.get("img_caption")
+    if isinstance(caption_raw, (list, tuple)):
+        caption = " ".join(str(part).strip() for part in caption_raw if str(part).strip())
+    else:
+        caption = _extract_text(caption_raw)
+    if not caption:
+        return ""
+    return f"*{caption}*"
+
+
+def _render_code(block: Block) -> str:
+    content = _extract_text(block.get("content"))
+    if not content:
+        return ""
+
+    language = _extract_text(block.get("language") or block.get("lang"))
+    fence = f"```{language}\n" if language else "```\n"
+    return f"{fence}{content}\n```"
+
+
+def _render_list(block: Block) -> str:
+    content = block.get("content")
+    if isinstance(content, list):
+        items = []
+        for item in content:
+            text = _extract_text(item)
+            if text:
+                items.append(f"- {text}")
+        return "\n".join(items)
+    text = _extract_text(content)
+    if not text:
+        return ""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    return "\n".join(f"- {line}" for line in lines)
+
+
+def _render_unknown(block: Block) -> str:
+    block_type = block.get("type")
+    LOGGER.warning("Encountered unknown block type: %s", block_type)
+    return _extract_text(block.get("content"))
+
+
+def _normalize_markdown(markdown: str) -> str:
+    text = markdown.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text.strip())
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+_BLOCK_RENDERERS: dict[str, Callable[[Block], str]] = {
+    "text": _render_text,
+    "paragraph": _render_text,
+    "table": _render_table,
+    "equation": _render_equation,
+    "image": _render_image,
+    "image_caption": _render_image_caption,
+    "code": _render_code,
+    "algorithm": _render_code,
+    "list": _render_list,
+}
+

--- a/tests/test_batch_processor_integration.py
+++ b/tests/test_batch_processor_integration.py
@@ -82,7 +82,13 @@ def main() -> int:
 
     stem = pdf_path.stem
     (output_dir / f"{stem}.md").write_text(f"# {stem}\\nProcessed", encoding="utf-8")
-    (output_dir / f"{stem}_content_list.json").write_text("{}", encoding="utf-8")
+    content_list = [
+        {"type": "text", "content": f"{stem} Title", "text_level": 1},
+        {"type": "text", "content": "Body paragraph."},
+    ]
+    (output_dir / f"{stem}_content_list.json").write_text(
+        json.dumps(content_list), encoding="utf-8"
+    )
     (output_dir / f"{stem}_middle.json").write_text("{}", encoding="utf-8")
     (output_dir / f"{stem}_model.json").write_text("{}", encoding="utf-8")
     (output_dir / f"{stem}_layout.pdf").write_bytes(b"%PDF-1.4\\n%")
@@ -267,6 +273,10 @@ def test_batch_processor_processes_pdfs_without_duplicates(tmp_path: Path, fake_
         assert (document_dir / "content_list.json").exists()
         assert (document_dir / "middle.json").exists()
         assert (document_dir / "model.json").exists()
+        structured_path = document_dir / f"{stem}.structured.md"
+        assert structured_path.exists()
+        structured_contents = structured_path.read_text(encoding="utf-8")
+        assert f"# {stem} Title" in structured_contents
         assert _attempts_for(pdf) == (3 if pdf == retry_pdf else 1)
 
     assert failed_path_for(failure_pdf).exists()

--- a/tests/test_markdown_builder.py
+++ b/tests/test_markdown_builder.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from MinerUExperiment.markdown_builder import (
+    MarkdownGenerationError,
+    blocks_to_markdown,
+    generate_structured_markdown,
+    load_content_list,
+    structured_markdown_path,
+)
+
+
+def test_load_content_list_success(tmp_path: Path) -> None:
+    data = [{"type": "text", "content": "Heading", "text_level": 1}]
+    path = tmp_path / "doc_content_list.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    blocks = load_content_list(path)
+
+    assert blocks == data
+
+
+def test_load_content_list_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "missing_content_list.json"
+    with pytest.raises(FileNotFoundError):
+        load_content_list(path)
+
+
+def test_load_content_list_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad_content_list.json"
+    path.write_text("{not valid", encoding="utf-8")
+
+    with pytest.raises(MarkdownGenerationError):
+        load_content_list(path)
+
+
+def test_blocks_to_markdown_handles_content_types() -> None:
+    blocks = [
+        {"type": "text", "content": "Title", "text_level": 1},
+        {"type": "text", "content": "Overview", "text_level": 2},
+        {"type": "text", "content": "Paragraph text."},
+        {"type": "text", "content": "Deep Heading", "text_level": 8},
+        {"type": "table", "html": "<table><tr><td>Cell</td></tr></table>"},
+        {"type": "equation", "content": "E=mc^2"},
+        {
+            "type": "image",
+            "img_path": "images/figure.png",
+            "img_caption": ["Figure", "One"],
+        },
+        {"type": "code", "content": "print('hi')", "language": "python"},
+        {"type": "list", "content": ["First", "Second"]},
+        {"type": "unknown", "content": "Fallback"},
+    ]
+
+    markdown = blocks_to_markdown(blocks)
+
+    assert "# Title" in markdown
+    assert "## Overview" in markdown
+    assert "Paragraph text." in markdown
+    assert "###### Deep Heading" in markdown
+    assert "<table><tr><td>Cell</td></tr></table>" in markdown
+    assert "$$\nE=mc^2\n$$" in markdown
+    assert "![Figure One](images/figure.png)" in markdown
+    assert "*Figure One*" in markdown
+    assert "```python\nprint('hi')\n```" in markdown
+    assert "- First" in markdown and "- Second" in markdown
+    assert "Fallback" in markdown
+
+    assert "\n\n\n" not in markdown
+
+
+def test_generate_structured_markdown_creates_file(tmp_path: Path) -> None:
+    blocks = [
+        {"type": "text", "content": "Doc Title", "text_level": 1},
+        {"type": "equation", "content": "x = 1"},
+    ]
+    content_path = tmp_path / "doc_content_list.json"
+    content_path.write_text(json.dumps(blocks), encoding="utf-8")
+
+    output_path = generate_structured_markdown(content_path)
+
+    expected_path = tmp_path / "doc.structured.md"
+    assert output_path == expected_path
+    assert expected_path.exists()
+
+    contents = expected_path.read_text(encoding="utf-8")
+    assert contents.startswith("# Doc Title")
+    assert contents.strip().endswith("$$")
+
+
+def test_structured_markdown_path_default(tmp_path: Path) -> None:
+    path = tmp_path / "chapter_content_list.json"
+    derived = structured_markdown_path(path)
+    assert derived.name == "chapter.structured.md"
+
+
+def test_blocks_to_markdown_tables_only() -> None:
+    blocks = [{"type": "table", "content": "<table></table>"}]
+
+    markdown = blocks_to_markdown(blocks)
+
+    assert markdown.strip() == "<table></table>"
+


### PR DESCRIPTION
## Summary
- add a markdown_builder module that converts MinerU content_list.json blocks into normalized structured Markdown
- generate .structured.md files during batch processing and provide a standalone CLI for retroactive post-processing
- cover the new functionality with unit and integration tests while marking the implementation checklist complete

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b42ee1bc832f97f960b5e478d2ba