### PR TITLE
Add progress instrumentation across MinerU workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "mineru[all]>=2.5.0",
     "psutil>=5.9.0",
+    "tqdm>=4.66.4",
 ]
 
 [tool.black]

--- a/src/MinerUExperiment/progress.py
+++ b/src/MinerUExperiment/progress.py
@@ -1,0 +1,75 @@
+"""Utilities for consistent tqdm progress reporting throughout the project."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from tqdm.auto import tqdm
+
+
+class ProgressBar:
+    """Light wrapper around :class:`tqdm.tqdm` with graceful disable support."""
+
+    def __init__(
+        self,
+        *,
+        total: Optional[int] = None,
+        enabled: bool = True,
+        leave: bool = True,
+        position: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._bar = (
+            tqdm(total=total, leave=leave, position=position, **kwargs)
+            if enabled
+            else None
+        )
+
+    def update(self, value: int = 1) -> None:
+        if self._bar is not None:
+            self._bar.update(value)
+
+    def set_description(self, description: str, refresh: bool = True) -> None:
+        if self._bar is not None:
+            self._bar.set_description(description, refresh=refresh)
+
+    def set_postfix(self, data: Optional[Dict[str, Any]] = None, refresh: bool = True) -> None:
+        if self._bar is not None and data is not None:
+            self._bar.set_postfix(data, refresh=refresh)
+
+    def write(self, message: str) -> None:
+        if self._bar is not None:
+            self._bar.write(message)
+
+    def close(self) -> None:
+        if self._bar is not None:
+            self._bar.close()
+
+    def __enter__(self) -> "ProgressBar":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[override]
+        self.close()
+
+
+def progress_iterable(
+    iterable: Iterable[Any],
+    *,
+    enabled: bool = True,
+    **kwargs: Any,
+) -> Iterator[Any]:
+    """Wrap *iterable* with :func:`tqdm.auto.tqdm` when *enabled* is True."""
+
+    if not enabled:
+        yield from iterable
+        return
+
+    for item in tqdm(iterable, **kwargs):
+        yield item
+
+
+__all__ = [
+    "ProgressBar",
+    "progress_iterable",
+]
+

--- a/src/MinerUExperiment/validation.py
+++ b/src/MinerUExperiment/validation.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from .gpu_utils import GPUInfo, GPUUnavailableError, enforce_gpu_environment, warmup_gpu
 from .mineru_config import MineruConfig, ModelDownloadError, ensure_model_downloaded, load_config
@@ -16,6 +16,7 @@ from .mineru_runner import (
     EXPECTED_OUTPUT_FILES,
     process_pdf,
 )
+from .progress import ProgressBar
 
 LOGGER = logging.getLogger(__name__)
 
@@ -123,6 +124,7 @@ def _measure_processing_run(
     config: MineruConfig,
     warmup: bool,
     expected_files: Sequence[str],
+    show_progress: bool,
 ) -> RunMetrics:
     start = time.perf_counter()
     try:
@@ -132,6 +134,7 @@ def _measure_processing_run(
             config=config,
             warmup=warmup,
             expected_files=expected_files,
+            show_progress=show_progress,
         )
     except MineruInvocationError as exc:
         raise ValidationFailure(str(exc)) from exc
@@ -145,6 +148,7 @@ def validate_pdf_processing(
     *,
     output_root: Optional[Path | str] = None,
     expected_files: Sequence[str] = EXPECTED_OUTPUT_FILES,
+    show_progress: bool = True,
 ) -> ValidationReport:
     """
     Execute MinerU against a PDF twice (cold vs warmed) and capture metrics.
@@ -162,46 +166,100 @@ def validate_pdf_processing(
     if not pdf.exists():
         raise FileNotFoundError(f"PDF not found: {pdf}")
 
-    config = load_config()
-    try:
-        ensure_model_downloaded(config=config)
-    except ModelDownloadError as exc:
-        raise ValidationFailure(str(exc)) from exc
+    with ProgressBar(
+        total=8,
+        desc="Validation pipeline",
+        unit="step",
+        enabled=show_progress,
+        leave=True,
+    ) as pipeline_bar:
+        pipeline_bar.set_postfix({"stage": "load config"})
+        config = load_config()
+        pipeline_bar.update()
 
-    devices = _parse_cuda_devices(config.cuda_visible_devices)
-    try:
-        gpu_info = enforce_gpu_environment(devices=devices)
-    except GPUUnavailableError as exc:
-        raise ValidationFailure(str(exc)) from exc
+        pipeline_bar.set_postfix({"stage": "ensure model"})
+        try:
+            ensure_model_downloaded(config=config)
+        except ModelDownloadError as exc:
+            raise ValidationFailure(str(exc)) from exc
+        pipeline_bar.update()
 
-    snapshot_before = _collect_gpu_snapshot()
+        pipeline_bar.set_postfix({"stage": "enforce gpu"})
+        devices = _parse_cuda_devices(config.cuda_visible_devices)
+        try:
+            gpu_info = enforce_gpu_environment(devices=devices)
+        except GPUUnavailableError as exc:
+            raise ValidationFailure(str(exc)) from exc
+        pipeline_bar.set_postfix(
+            {
+                "stage": "enforce gpu",
+                "cuda": f"device {gpu_info.index}",
+                "gpu": gpu_info.name,
+                "backend": config.backend_name,
+            }
+        )
+        pipeline_bar.update()
 
-    base_output_root = Path(output_root).expanduser().resolve() if output_root else pdf.parent
-    cold_output = base_output_root / f"{pdf.stem}_cold"
-    warm_output = base_output_root / f"{pdf.stem}_warm"
+        pipeline_bar.set_postfix({"stage": "gpu snapshot (before)"})
+        snapshot_before = _collect_gpu_snapshot()
+        pipeline_bar.update()
 
-    cold_metrics = _measure_processing_run(
-        pdf,
-        output_dir=cold_output,
-        config=config,
-        warmup=False,
-        expected_files=expected_files,
-    )
+        base_output_root = (
+            Path(output_root).expanduser().resolve() if output_root else pdf.parent
+        )
+        cold_output = base_output_root / f"{pdf.stem}_cold"
+        warm_output = base_output_root / f"{pdf.stem}_warm"
 
-    try:
-        warmup_duration = warmup_gpu(devices[0])
-    except GPUUnavailableError as exc:
-        raise ValidationFailure(str(exc)) from exc
+        with ProgressBar(
+            total=1,
+            desc=f"{pdf.name} cold run",
+            unit="doc",
+            enabled=show_progress,
+            leave=False,
+            position=1,
+        ) as run_bar:
+            pipeline_bar.set_postfix({"stage": "cold run", "output": cold_output.name})
+            cold_metrics = _measure_processing_run(
+                pdf,
+                output_dir=cold_output,
+                config=config,
+                warmup=False,
+            expected_files=expected_files,
+            show_progress=False,
+        )
+            run_bar.update()
+        pipeline_bar.update()
 
-    warm_metrics = _measure_processing_run(
-        pdf,
-        output_dir=warm_output,
-        config=config,
-        warmup=False,
-        expected_files=expected_files,
-    )
+        pipeline_bar.set_postfix({"stage": "gpu warmup"})
+        try:
+            warmup_duration = warmup_gpu(devices[0], show_progress=show_progress)
+        except GPUUnavailableError as exc:
+            raise ValidationFailure(str(exc)) from exc
+        pipeline_bar.update()
 
-    snapshot_after = _collect_gpu_snapshot()
+        with ProgressBar(
+            total=1,
+            desc=f"{pdf.name} warm run",
+            unit="doc",
+            enabled=show_progress,
+            leave=False,
+            position=1,
+        ) as run_bar:
+            pipeline_bar.set_postfix({"stage": "warm run", "output": warm_output.name})
+            warm_metrics = _measure_processing_run(
+                pdf,
+                output_dir=warm_output,
+                config=config,
+                warmup=False,
+            expected_files=expected_files,
+            show_progress=False,
+        )
+            run_bar.update()
+        pipeline_bar.update()
+
+        pipeline_bar.set_postfix({"stage": "gpu snapshot (after)"})
+        snapshot_after = _collect_gpu_snapshot()
+        pipeline_bar.update()
 
     return ValidationReport(
         pdf_path=pdf,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -138,6 +138,7 @@ def test_process_pdf_success(
         output_dir=output_dir,
         config=config,
         warmup=False,
+        show_progress=False,
     )
 
     assert isinstance(result, MineruProcessResult)
@@ -180,6 +181,7 @@ def test_process_pdf_missing_output(
         output_dir=output_dir,
         config=config,
         warmup=False,
+        show_progress=False,
     )
 
     assert not result.success

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,7 +70,7 @@ def test_validate_pdf_processing_success(
         raising=False,
     )
     monkeypatch.setattr(validation, "_collect_gpu_snapshot", lambda: "snapshot", raising=False)
-    monkeypatch.setattr(validation, "warmup_gpu", lambda device: 1.5, raising=False)
+    monkeypatch.setattr(validation, "warmup_gpu", lambda *_, **__: 1.5, raising=False)
 
     def fake_process_pdf(*args, **kwargs):
         call_sequence.append(kwargs.get("output_dir").name)
@@ -81,7 +81,11 @@ def test_validate_pdf_processing_success(
     times = iter([0.0, 3.0, 10.0, 12.0])
     monkeypatch.setattr(validation.time, "perf_counter", lambda: next(times), raising=False)
 
-    report = validation.validate_pdf_processing(pdf_file, output_root=tmp_path)
+    report = validation.validate_pdf_processing(
+        pdf_file,
+        output_root=tmp_path,
+        show_progress=False,
+    )
 
     assert report.baseline.duration_seconds == 3.0
     assert report.warmed.duration_seconds == 2.0
@@ -126,7 +130,7 @@ def test_validate_pdf_processing_failure_raises(
         raising=False,
     )
     monkeypatch.setattr(validation, "_collect_gpu_snapshot", lambda: None, raising=False)
-    monkeypatch.setattr(validation, "warmup_gpu", lambda device: 1.0, raising=False)
+    monkeypatch.setattr(validation, "warmup_gpu", lambda *_, **__: 1.0, raising=False)
 
     def failing_process_pdf(*args, **kwargs):
         return MineruProcessResult(
@@ -142,7 +146,11 @@ def test_validate_pdf_processing_failure_raises(
     monkeypatch.setattr(validation.time, "perf_counter", lambda: 0.0, raising=False)
 
     with pytest.raises(ValidationFailure):
-        validation.validate_pdf_processing(pdf_file, output_root=tmp_path)
+        validation.validate_pdf_processing(
+            pdf_file,
+            output_root=tmp_path,
+            show_progress=False,
+        )
 
 
 def test_metrics_collector_generates_report(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add reusable tqdm progress utilities and depend on tqdm for the project
- surface detailed progress information during GPU warmup, single-document runs, and validation workflows
- enhance batch processing with environment status reporting, live document tracking, and updated tests to accommodate progress controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b7193efc832f92beb3ec51c46fec