### PR TITLE
Add OpenSpec proposals for dynamic batching improvements

### DIFF
--- a/openspec/changes/update-dynamic-batch-tracking/proposal.md
+++ b/openspec/changes/update-dynamic-batch-tracking/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: Dynamic Batch Queue Tracking
+
+## Why
+
+The batch processor determines the total number of PDFs once at startup and stops the run when the original count has been processed. When new PDFs arrive (or stale locks are reclaimed) while the batch is running, workers are told to shut down even if there are still unprocessed files on disk. This prematurely ends long-running ingestion jobs and forces manual restarts to pick up the backlog.
+
+## What Changes
+
+- Rework batch orchestration to treat the input directory as a live queue until it is truly empty.
+- Recompute remaining work as workers finish, growing the progress totals when new PDFs appear and only exiting after the queue has drained for a configurable quiet period.
+- Surface the dynamic totals in progress output and the final summary so operators can see how many PDFs were discovered after startup.
+
+## Impact
+
+- Affected specs: **batch-processing** (existing capability)
+- Affected code:
+  - `src/MinerUExperiment/batch_processor.py`
+  - `scripts/process_batch.py`
+  - `tests/test_batch_processor_integration.py`
+- Tooling: none (reuse existing CLI)

--- a/openspec/changes/update-dynamic-batch-tracking/specs/batch-processing/spec.md
+++ b/openspec/changes/update-dynamic-batch-tracking/specs/batch-processing/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: PDF Directory Scanning
+
+#### Scenario: Pick up PDFs arriving mid-run
+
+- **GIVEN** the batch run has already started
+- **WHEN** a new `.pdf` file appears under PDFsToProcess
+- **THEN** the system SHALL discover the new file
+- **AND** it SHALL enqueue the PDF for processing before the batch completes
+
+### Requirement: Parallel Worker Execution
+
+#### Scenario: Continue until queue drained
+
+- **GIVEN** workers are running
+- **AND** new PDFs or reclaimed stale locks increase the pending queue
+- **WHEN** the worker pool finishes the original set of PDFs
+- **THEN** the orchestrator SHALL keep workers alive until no pending PDFs remain for a configured quiet period
+- **AND** it SHALL NOT signal shutdown while work is still queued
+
+### Requirement: Progress Tracking
+
+#### Scenario: Dynamic totals for late arrivals
+
+- **WHEN** additional PDFs are discovered after processing begins
+- **THEN** the progress display SHALL refresh the total/remaining counts to include them
+- **AND** the final summary SHALL report how many PDFs were processed after startup

--- a/openspec/changes/update-dynamic-batch-tracking/tasks.md
+++ b/openspec/changes/update-dynamic-batch-tracking/tasks.md
@@ -1,0 +1,17 @@
+# Implementation Tasks
+
+## 1. Batch Processor Orchestration
+
+- [ ] 1.1 Track pending PDF count dynamically inside `BatchProcessor.run`.
+- [ ] 1.2 Keep workers alive until the coordinator reports no pending PDFs for a configurable quiet period.
+- [ ] 1.3 Expand summary bookkeeping to include PDFs discovered after startup.
+
+## 2. Progress Reporting
+
+- [ ] 2.1 Update progress bars and log messages to refresh the total/remaining counts when new PDFs appear.
+- [ ] 2.2 Add configuration (and CLI flag) for the quiet-period timeout controlling when the batch is considered drained.
+
+## 3. Testing & Documentation
+
+- [ ] 3.1 Extend integration tests to cover PDFs added mid-run and ensure they are processed before shutdown.
+- [ ] 3.2 Document the dynamic-queue behavior in README/CLI help so operators know late files are supported.

--- a/openspec/changes/update-failed-retry-controls/proposal.md
+++ b/openspec/changes/update-failed-retry-controls/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: Retry Controls for Failed PDFs
+
+## Why
+
+Once a PDF exhausts all retry attempts the coordinator writes a `.failed` marker next to the source file and future batch runs skip it entirely. Operators must manually delete the marker files to try again, which is error-prone for large batches and prevents unattended recovery from transient issues (e.g., temporary GPU hiccups or model updates).
+
+## What Changes
+
+- Add explicit controls to requeue previously failed PDFs, either via a CLI flag (`--retry-failed`) or by honoring an expiration window on `.failed` markers.
+- Track and report how many failed PDFs were retried during the run so operators understand what was automatically reprocessed.
+- Document the new workflow so users know how to clear dead-letter items without manual filesystem surgery.
+
+## Impact
+
+- Affected specs: **batch-processing** (existing capability)
+- Affected code:
+  - `src/MinerUExperiment/worker_coordinator.py`
+  - `src/MinerUExperiment/batch_processor.py`
+  - `scripts/process_batch.py`
+  - `tests/test_batch_processor_integration.py`

--- a/openspec/changes/update-failed-retry-controls/specs/batch-processing/spec.md
+++ b/openspec/changes/update-failed-retry-controls/specs/batch-processing/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Error Handling and Retry
+
+#### Scenario: Requeue previously failed PDFs
+
+- **GIVEN** a PDF has a `.failed` marker from a prior run
+- **WHEN** batch processing is invoked with retry controls enabled
+- **THEN** the system SHALL delete or ignore the marker
+- **AND** it SHALL attempt to process the PDF again
+- **AND** it SHALL record that the document was retried in the run summary
+
+#### Scenario: Failed marker expiration
+
+- **WHEN** a `.failed` marker exceeds the configured expiration window
+- **THEN** the system SHALL treat the PDF as pending work
+- **AND** it SHALL regenerate the failure marker if the PDF fails again
+
+### Requirement: CLI Interface
+
+#### Scenario: Retry failed flag
+
+- **WHEN** `scripts/process_batch.py --retry-failed` is executed
+- **THEN** the CLI SHALL enable automatic reprocessing of `.failed` PDFs
+- **AND** it SHALL accept an optional `--failed-expiry-hours` override
+- **AND** the help output SHALL describe both options

--- a/openspec/changes/update-failed-retry-controls/tasks.md
+++ b/openspec/changes/update-failed-retry-controls/tasks.md
@@ -1,0 +1,18 @@
+# Implementation Tasks
+
+## 1. Coordinator Enhancements
+
+- [ ] 1.1 Accept options to include `.failed` PDFs when retrying.
+- [ ] 1.2 Support age-based expiration for `.failed` markers so stale failures automatically requeue.
+- [ ] 1.3 Expose metadata about retried failures for downstream reporting.
+
+## 2. Batch Processor & CLI
+
+- [ ] 2.1 Add configuration fields and CLI flags (`--retry-failed`, `--failed-expiry-hours`) to control retry behavior.
+- [ ] 2.2 Update worker orchestration to mark retried items distinctly in progress and summaries.
+- [ ] 2.3 Ensure permanent failures still produce `.failed` markers when retries are exhausted again.
+
+## 3. Testing & Docs
+
+- [ ] 3.1 Extend integration tests to cover reruns that automatically pick up `.failed` PDFs.
+- [ ] 3.2 Document the new retry controls in README and CLI help text.


### PR DESCRIPTION
## Summary
- add the `update-dynamic-batch-tracking` proposal to keep batch runs alive until the queue actually drains and report dynamic totals
- add the `update-failed-retry-controls` proposal to introduce CLI-controlled reprocessing of PDFs marked as failed in previous runs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4bbd085e8832f9f7eb38a235066d8