### PR TITLE
Add comprehensive tests for process_batch pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+import MinerUExperiment.batch_processor as batch_processor
+from MinerUExperiment.batch_processor import BatchProcessor, BatchSummary
+
+
+STUB_SCRIPT = """#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _load_behavior(pdf_path: Path) -> dict:
+    behavior_path = pdf_path.with_suffix(pdf_path.suffix + ".behavior.json")
+    if behavior_path.exists():
+        try:
+            return json.loads(behavior_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--pdf", dest="pdf_path", required=True)
+    parser.add_argument("-o", "--output", dest="output_dir", required=True)
+    parser.add_argument("-b", "--backend", dest="backend", required=True)
+    args, _ = parser.parse_known_args()
+
+    pdf_path = Path(args.pdf_path)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    behavior = _load_behavior(pdf_path)
+    sleep = float(behavior.get("sleep", os.environ.get("MINERU_TEST_SLEEP", 0)))
+    failures_before_success = int(behavior.get("failures_before_success", 0))
+    permanent_failure = bool(behavior.get("permanent_failure", False))
+
+    attempts_path = pdf_path.with_suffix(pdf_path.suffix + ".attempts")
+    attempts = 0
+    if attempts_path.exists():
+        try:
+            attempts = int(attempts_path.read_text(encoding="utf-8"))
+        except ValueError:
+            attempts = 0
+    attempts += 1
+    attempts_path.write_text(str(attempts), encoding="utf-8")
+
+    if sleep:
+        time.sleep(float(sleep))
+
+    if permanent_failure:
+        sys.stderr.write(
+            f"permanent failure for {pdf_path.name} on attempt {attempts}\\n"
+        )
+        return 1
+
+    if attempts <= failures_before_success:
+        sys.stderr.write(
+            f"transient failure for {pdf_path.name} on attempt {attempts}/{failures_before_success}\\n"
+        )
+        return 1
+
+    stem = pdf_path.stem
+    (output_dir / f"{stem}.md").write_text(
+        f"# {stem}\\nProcessed", encoding="utf-8"
+    )
+    content_list = [
+        {"type": "text", "content": f"{stem} Title", "text_level": 1},
+        {"type": "text", "content": "Body paragraph."},
+    ]
+    (output_dir / f"{stem}_content_list.json").write_text(
+        json.dumps(content_list), encoding="utf-8"
+    )
+    (output_dir / f"{stem}_middle.json").write_text("{}", encoding="utf-8")
+    (output_dir / f"{stem}_model.json").write_text("{}", encoding="utf-8")
+    (output_dir / f"{stem}_layout.pdf").write_bytes(b"%PDF-1.4%")
+    (output_dir / f"{stem}_origin.pdf").write_bytes(b"%PDF-1.4%")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+"""
+
+
+class DummyMetrics:
+    def __init__(self, *, output_dir: Path, sample_interval: float, gpu_index: int, benchmark_mode: bool):
+        self.output_dir = output_dir
+        self.sample_interval = sample_interval
+        self.gpu_index = gpu_index
+        self.benchmark_mode = benchmark_mode
+        self.started = False
+
+    def start(self) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+    def record_pdf_start(self, *_, **__) -> None:  # pragma: no cover - noop
+        return
+
+    def record_pdf_end(self, *_, **__) -> None:  # pragma: no cover - noop
+        return
+
+    def generate_report(self, *, summary: BatchSummary, profile: str) -> Path:
+        report_path = self.output_dir / "report.json"
+        data = {
+            "profile": profile,
+            "processed": summary.processed,
+            "succeeded": summary.succeeded,
+            "failed": summary.failed,
+        }
+        report_path.write_text(json.dumps(data), encoding="utf-8")
+        return report_path
+
+
+class DummyMineruConfig:
+    def __init__(self) -> None:
+        self.vllm_settings = type(
+            "VllmSettings",
+            (),
+            {
+                "data_parallel_size": 1,
+                "tensor_parallel_size": 1,
+                "max_model_len": 16384,
+                "dtype": "float16",
+                "gpu_memory_utilization": 0.9,
+                "block_size": 16,
+                "swap_space_mb": 8192,
+            },
+        )()
+
+    def update_vllm_settings(self, **settings: object) -> None:
+        for key, value in settings.items():
+            setattr(self.vllm_settings, key, value)
+
+
+@pytest.fixture(autouse=True)
+def stub_batch_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(batch_processor, "MetricsCollector", DummyMetrics, raising=False)
+    monkeypatch.setattr(batch_processor, "load_config", lambda: DummyMineruConfig(), raising=False)
+    monkeypatch.setattr(batch_processor, "write_config", lambda config: None, raising=False)
+    monkeypatch.setattr(
+        BatchProcessor,
+        "_resolve_dtype_preference",
+        lambda self: "float16",
+        raising=False,
+    )
+    monkeypatch.setattr(BatchProcessor, "_validate_resources", lambda self: None, raising=False)
+    monkeypatch.setattr(BatchProcessor, "_start_resource_monitor", lambda self: None, raising=False)
+    monkeypatch.setattr(BatchProcessor, "_stop_resource_monitor", lambda self: None, raising=False)
+
+
+@pytest.fixture
+def fake_mineru(tmp_path: Path) -> Path:
+    script_path = tmp_path / "fake_mineru.py"
+    script_path.write_text(STUB_SCRIPT, encoding="utf-8")
+    script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
+    return script_path

--- a/tests/test_batch_processor_configuration.py
+++ b/tests/test_batch_processor_configuration.py
@@ -1,0 +1,99 @@
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from MinerUExperiment.batch_processor import (
+    BatchProcessorConfig,
+    _mineru_command,
+    _worker_env,
+)
+
+
+def _make_config(tmp_path: Path) -> BatchProcessorConfig:
+    input_dir = tmp_path / "inputs"
+    output_dir = tmp_path / "outputs"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    return BatchProcessorConfig(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        workers=3,
+        poll_interval=0.5,
+        max_retries=2,
+        retry_delay=1.0,
+        progress_interval=1.5,
+        mineru_cli="mineru",
+        mineru_backend="backend",
+        mineru_extra_args=("--foo", "bar"),
+        env_overrides={"CUSTOM": "1", "OMP_NUM_THREADS": "16"},
+        log_progress=True,
+        memory_pause_threshold=0.85,
+        memory_resume_threshold=0.75,
+        cpu_pause_threshold=0.93,
+        resource_monitor_interval=1.0,
+        gpu_memory_utilization=0.88,
+        tensor_parallel_size=2,
+        data_parallel_size=3,
+        max_model_len=2048,
+        block_size=8,
+        swap_space_mb=4096,
+        dtype="float16",
+        worker_memory_limit_gb=8.0,
+    )
+
+
+def test_worker_env_populates_defaults_and_preserves_overrides(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    env = _worker_env(config)
+
+    assert env["CUSTOM"] == "1"
+    assert env["OMP_NUM_THREADS"] == "16"
+    assert env["MKL_NUM_THREADS"] == str(config.mkl_threads)
+    assert env["MINERU_VLLM_GPU_MEMORY_UTILIZATION"] == f"{config.gpu_memory_utilization:.2f}"
+    assert env["MINERU_VLLM_TENSOR_PARALLEL_SIZE"] == str(config.tensor_parallel_size)
+    assert env["MINERU_VLLM_DATA_PARALLEL_SIZE"] == str(config.data_parallel_size)
+    assert env["MINERU_VLLM_MAX_MODEL_LEN"] == str(config.max_model_len)
+    assert env["MINERU_VLLM_BLOCK_SIZE"] == str(config.block_size)
+    assert env["MINERU_VLLM_SWAP_SPACE_MB"] == str(config.swap_space_mb)
+    assert env["MINERU_VLLM_DTYPE"] == config.dtype
+
+
+def test_mineru_command_includes_extra_args(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    pdf_path = config.input_dir / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%EOF")
+    output_dir = config.output_dir / "doc"
+    command = _mineru_command(
+        cli=config.mineru_cli,
+        pdf_path=pdf_path,
+        output_dir=output_dir,
+        backend=config.mineru_backend,
+        extra_args=config.mineru_extra_args,
+    )
+
+    assert command[:7] == [
+        config.mineru_cli,
+        "-p",
+        str(pdf_path),
+        "-o",
+        str(output_dir),
+        "-b",
+        config.mineru_backend,
+    ]
+    assert list(config.mineru_extra_args) == command[7:]
+
+
+def test_worker_env_isolated_per_call(tmp_path: Path, monkeypatch) -> None:
+    config = _make_config(tmp_path)
+    monkeypatch.setenv("MINERU_VLLM_GPU_MEMORY_UTILIZATION", "0.11")
+    env = _worker_env(config)
+
+    assert env["MINERU_VLLM_GPU_MEMORY_UTILIZATION"] == "0.11"
+    os.environ.pop("MINERU_VLLM_GPU_MEMORY_UTILIZATION", None)
+    env2 = _worker_env(config)
+    assert env2["MINERU_VLLM_GPU_MEMORY_UTILIZATION"] == f"{config.gpu_memory_utilization:.2f}"

--- a/tests/test_batch_processor_integration.py
+++ b/tests/test_batch_processor_integration.py
@@ -1,20 +1,16 @@
 import json
 import os
-import stat
 import sys
 import threading
 import time
 from pathlib import Path
-
-import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = PROJECT_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-import MinerUExperiment.batch_processor as batch_processor
-from MinerUExperiment.batch_processor import BatchProcessor, BatchProcessorConfig, BatchSummary
+from MinerUExperiment.batch_processor import BatchProcessor, BatchProcessorConfig
 from MinerUExperiment.worker_coordinator import (
     done_path_for,
     failed_path_for,
@@ -22,185 +18,27 @@ from MinerUExperiment.worker_coordinator import (
 )
 
 
-STUB_SCRIPT = """#!/usr/bin/env python3
-import argparse
-import json
-import os
-import sys
-import time
-from pathlib import Path
-
-
-def _load_behavior(pdf_path: Path) -> dict:
-    behavior_path = pdf_path.with_suffix(pdf_path.suffix + ".behavior.json")
-    if behavior_path.exists():
-        try:
-            return json.loads(behavior_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            return {}
-    return {}
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--pdf", dest="pdf_path", required=True)
-    parser.add_argument("-o", "--output", dest="output_dir", required=True)
-    parser.add_argument("-b", "--backend", dest="backend", required=True)
-    args, _ = parser.parse_known_args()
-
-    pdf_path = Path(args.pdf_path)
-    output_dir = Path(args.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    behavior = _load_behavior(pdf_path)
-    sleep = float(behavior.get("sleep", os.environ.get("MINERU_TEST_SLEEP", 0)))
-    failures_before_success = int(behavior.get("failures_before_success", 0))
-    permanent_failure = bool(behavior.get("permanent_failure", False))
-
-    attempts_path = pdf_path.with_suffix(pdf_path.suffix + ".attempts")
-    attempts = 0
-    if attempts_path.exists():
-        try:
-            attempts = int(attempts_path.read_text(encoding="utf-8"))
-        except ValueError:
-            attempts = 0
-    attempts += 1
-    attempts_path.write_text(str(attempts), encoding="utf-8")
-
-    if sleep:
-        time.sleep(float(sleep))
-
-    if permanent_failure:
-        sys.stderr.write(f"permanent failure for {pdf_path.name} on attempt {attempts}\\n")
-        return 1
-
-    if attempts <= failures_before_success:
-        sys.stderr.write(
-            f"transient failure for {pdf_path.name} on attempt {attempts}/{failures_before_success}\\n"
-        )
-        return 1
-
-    stem = pdf_path.stem
-    (output_dir / f"{stem}.md").write_text(f"# {stem}\\nProcessed", encoding="utf-8")
-    content_list = [
-        {"type": "text", "content": f"{stem} Title", "text_level": 1},
-        {"type": "text", "content": "Body paragraph."},
-    ]
-    (output_dir / f"{stem}_content_list.json").write_text(
-        json.dumps(content_list), encoding="utf-8"
-    )
-    (output_dir / f"{stem}_middle.json").write_text("{}", encoding="utf-8")
-    (output_dir / f"{stem}_model.json").write_text("{}", encoding="utf-8")
-    (output_dir / f"{stem}_layout.pdf").write_bytes(b"%PDF-1.4\\n%")
-    (output_dir / f"{stem}_origin.pdf").write_bytes(b"%PDF-1.4\\n%")
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
-"""
-
-
-class DummyMetrics:
-    def __init__(self, *, output_dir: Path, sample_interval: float, gpu_index: int, benchmark_mode: bool):
-        self.output_dir = output_dir
-        self.sample_interval = sample_interval
-        self.gpu_index = gpu_index
-        self.benchmark_mode = benchmark_mode
-        self.started = False
-
-    def start(self) -> None:
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        self.started = True
-
-    def stop(self) -> None:
-        self.started = False
-
-    def record_pdf_start(self, *_, **__) -> None:  # pragma: no cover - noop
-        return
-
-    def record_pdf_end(self, *_, **__) -> None:  # pragma: no cover - noop
-        return
-
-    def generate_report(self, *, summary: BatchSummary, profile: str) -> Path:
-        report_path = self.output_dir / "report.json"
-        data = {
-            "profile": profile,
-            "processed": summary.processed,
-            "succeeded": summary.succeeded,
-            "failed": summary.failed,
-        }
-        report_path.write_text(json.dumps(data), encoding="utf-8")
-        return report_path
-
-
-class DummyMineruConfig:
-    def __init__(self) -> None:
-        self.vllm_settings = type(
-            "VllmSettings",
-            (),
-            {
-                "data_parallel_size": 1,
-                "tensor_parallel_size": 1,
-                "max_model_len": 16384,
-                "dtype": "float16",
-                "gpu_memory_utilization": 0.9,
-                "block_size": 16,
-                "swap_space_mb": 8192,
-            },
-        )()
-
-    def update_vllm_settings(self, **settings: object) -> None:
-        for key, value in settings.items():
-            setattr(self.vllm_settings, key, value)
-
-
-@pytest.fixture(autouse=True)
-def stub_batch_environment(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(batch_processor, "MetricsCollector", DummyMetrics, raising=False)
-    monkeypatch.setattr(batch_processor, "load_config", lambda: DummyMineruConfig(), raising=False)
-    monkeypatch.setattr(batch_processor, "write_config", lambda config: None, raising=False)
-    monkeypatch.setattr(
-        BatchProcessor,
-        "_resolve_dtype_preference",
-        lambda self: "float16",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        BatchProcessor,
-        "_start_resource_monitor",
-        lambda self: None,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        BatchProcessor,
-        "_stop_resource_monitor",
-        lambda self: None,
-        raising=False,
-    )
-
-
-@pytest.fixture
-def fake_mineru(tmp_path: Path) -> Path:
-    script_path = tmp_path / "fake_mineru.py"
-    script_path.write_text(STUB_SCRIPT, encoding="utf-8")
-    script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
-    return script_path
-
-
 def _create_pdf(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"%PDF-1.4\n%EOF\n")
 
 
-def _set_behavior(path: Path, *, sleep: float | None = None, failures_before_success: int = 0, permanent_failure: bool = False) -> None:
+def _set_behavior(
+    path: Path,
+    *,
+    sleep: float | None = None,
+    failures_before_success: int = 0,
+    permanent_failure: bool = False,
+) -> None:
     behavior = {
         "failures_before_success": failures_before_success,
         "permanent_failure": permanent_failure,
     }
     if sleep is not None:
         behavior["sleep"] = sleep
-    path.with_suffix(path.suffix + ".behavior.json").write_text(json.dumps(behavior), encoding="utf-8")
+    path.with_suffix(path.suffix + ".behavior.json").write_text(
+        json.dumps(behavior), encoding="utf-8"
+    )
 
 
 def _attempts_for(path: Path) -> int:
@@ -210,7 +48,15 @@ def _attempts_for(path: Path) -> int:
     return int(attempts_path.read_text(encoding="utf-8"))
 
 
-def test_batch_processor_processes_pdfs_without_duplicates(tmp_path: Path, fake_mineru: Path) -> None:
+def test_fake_mineru_fixture_available(fake_mineru: Path) -> None:
+    """Sanity check that the stub mineru CLI fixture is usable across modules."""
+    assert fake_mineru.exists()
+    assert os.access(fake_mineru, os.X_OK)
+
+
+def test_batch_processor_processes_pdfs_without_duplicates(
+    tmp_path: Path, fake_mineru: Path
+) -> None:
     input_dir = tmp_path / "PDFsToProcess"
     output_dir = tmp_path / "MDFilesCreated"
     input_dir.mkdir()
@@ -326,7 +172,6 @@ def test_batch_processor_graceful_shutdown(tmp_path: Path, fake_mineru: Path) ->
             if any(done_path_for(pdf).exists() for pdf in pdfs):
                 break
             if any(_attempts_for(pdf) > 0 for pdf in pdfs):
-                # Workers started but no completions yet; wait a little longer.
                 time.sleep(0.05)
                 continue
             time.sleep(0.05)

--- a/tests/test_process_batch.py
+++ b/tests/test_process_batch.py
@@ -1,0 +1,175 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from MinerUExperiment.batch_processor import BatchSummary
+from MinerUExperiment.worker_coordinator import done_path_for
+from scripts import process_batch
+
+
+def test_parse_args_defaults() -> None:
+    args = process_batch.parse_args([])
+    assert args.input_dir == Path("PDFsToProcess")
+    assert args.output_dir == Path("MDFilesCreated")
+    assert args.workers is None
+    assert args.max_retries == 3
+    assert args.retry_delay == pytest.approx(10.0)
+    assert args.extra_arg is None
+    assert args.env is None
+    assert args.profile == "balanced"
+    assert not args.no_progress
+
+
+def test_build_config_applies_profile_and_overrides(tmp_path: Path) -> None:
+    input_dir = tmp_path / "inputs"
+    output_dir = tmp_path / "outputs"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    args = process_batch.parse_args(
+        [
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--workers",
+            "3",
+            "--max-retries",
+            "5",
+            "--retry-delay",
+            "2.5",
+            "--poll-interval",
+            "0.4",
+            "--progress-interval",
+            "0.7",
+            "--backend",
+            "custom-backend",
+            "--mineru-cli",
+            "mineru-cli",
+            "--extra-arg=--alpha",
+            "--extra-arg=--beta",
+            "--env",
+            "OMP_NUM_THREADS=32",
+            "--env",
+            "CUSTOM=VALUE",
+            "--profile",
+            "throughput",
+            "--benchmark",
+        ]
+    )
+
+    config = process_batch.build_config(args)
+
+    assert config.input_dir == input_dir.resolve()
+    assert config.output_dir == output_dir.resolve()
+    assert config.workers == 3
+    assert config.max_retries == 5
+    assert config.retry_delay == pytest.approx(2.5)
+    assert config.poll_interval == pytest.approx(0.4)
+    assert config.progress_interval == pytest.approx(0.7)
+    assert config.mineru_backend == "custom-backend"
+    assert config.mineru_cli == "mineru-cli"
+    assert config.profile == "throughput"
+    assert config.benchmark is True
+    assert config.performance_report_path == output_dir / "performance_report.json"
+
+    assert config.mineru_extra_args[:2] == ("--alpha", "--beta")
+    assert config.mineru_extra_args[2:] == ("--batch-mode", "aggressive")
+
+    assert config.env_overrides["CUSTOM"] == "VALUE"
+    assert config.env_overrides["OMP_NUM_THREADS"] == "32"
+    assert "PYTORCH_CUDA_ALLOC_CONF" in config.env_overrides
+
+
+def test_main_returns_failure_code_on_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_dir = tmp_path / "inputs"
+    output_dir = tmp_path / "outputs"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    class FakeBatchProcessor:
+        def __init__(self, config: process_batch.BatchProcessorConfig) -> None:
+            self.config = config
+
+        def run(self) -> BatchSummary:
+            return BatchSummary(total=1, processed=1, succeeded=0, failed=1, skipped=0, duration_seconds=1.0)
+
+    monkeypatch.setattr(process_batch, "BatchProcessor", FakeBatchProcessor, raising=False)
+
+    exit_code = process_batch.main(
+        [
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 2
+
+
+def test_main_profile_info(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = process_batch.main(["--profile-info"])
+    out, err = capsys.readouterr()
+    assert exit_code == 0
+    assert "Performance profiles:" in out
+    assert err == ""
+
+
+def test_main_end_to_end_success(tmp_path: Path, fake_mineru: Path) -> None:
+    input_dir = tmp_path / "PDFsToProcess"
+    output_dir = tmp_path / "MDFilesCreated"
+    input_dir.mkdir()
+
+    pdf_one = input_dir / "doc1.pdf"
+    pdf_one.write_bytes(b"%PDF-1.4\n%EOF")
+    pdf_two = input_dir / "nested" / "doc2.pdf"
+    pdf_two.parent.mkdir(parents=True, exist_ok=True)
+    pdf_two.write_bytes(b"%PDF-1.4\n%EOF")
+
+    exit_code = process_batch.main(
+        [
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--workers",
+            "1",
+            "--mineru-cli",
+            str(fake_mineru),
+            "--backend",
+            "test-backend",
+            "--poll-interval",
+            "0.1",
+            "--progress-interval",
+            "0.2",
+            "--retry-delay",
+            "0.05",
+        ]
+    )
+
+    assert exit_code == 0
+
+    for pdf in (pdf_one, pdf_two):
+        assert done_path_for(pdf).exists()
+        relative = pdf.relative_to(input_dir)
+        document_dir = output_dir / relative.parent
+        stem = relative.stem
+        structured_path = document_dir / f"{stem}.structured.md"
+        assert structured_path.exists()
+        contents = structured_path.read_text(encoding="utf-8")
+        assert f"# {stem} Title" in contents
+
+    report_path = output_dir / "performance_report.json"
+    assert report_path.exists()
+
+    lock_files = list(input_dir.rglob("*.lock"))
+    assert not lock_files


### PR DESCRIPTION
## Summary
- introduce shared test fixtures and stub MinerU CLI in `tests/conftest.py`
- expand integration coverage for `BatchProcessor`, including configuration and end-to-end scenarios driven via `process_batch.py`
- add targeted unit tests for worker environment construction and CLI argument parsing/building

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e4be57b358832fb3f8550f7841478b